### PR TITLE
Fix icon mappings for Android and web

### DIFF
--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -18,6 +18,9 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'message.fill': 'message',
+  calendar: 'calendar-today',
+  'doc.text.fill': 'description',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- add missing icon mappings in `IconSymbol.tsx` so that non-iOS platforms display icons for message, calendar and notes

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules and type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683fd8690a8083289b878378ae57179d